### PR TITLE
update VideoRenderer.cs

### DIFF
--- a/CinematicRendererMod_Framework/Mono/src/VideoRenderer.cs
+++ b/CinematicRendererMod_Framework/Mono/src/VideoRenderer.cs
@@ -108,9 +108,9 @@ namespace LemmyModFramework
             { 
                 Process process = new Process();
                 process.StartInfo.FileName = "CMD.exe";
-                string args = "/C .\\ffmpeg.exe " + "-pattern_type sequence -i \"" + dir +
-                              "\\Video_%05d.tga\" -c:v libx264 -pix_fmt yuv444p -r 60 -s:v " + Screen.width + "x" +
-                              Screen.height + " \"" + dir + "\\out.mp4\"";
+                string args = "/C .\\ffmpeg.exe " + "-pattern_type sequence -r 60 -i \"" + dir +
+                              "\\Video_%05d.tga\" -c:v libx264 -preset veryfast -pix_fmt yuv444p -r 60 -b:v "Screen.width * Screen.height * 24"M -s:v " + Screen.width + "x" +
+                              Screen.height + " \"" + dir + "\\CINEMATIC_" + DateTime.Now.ToString("yyyy-MM-dd_hh-mm-ss") + ".MP4\"" ;
                 process.StartInfo.Arguments = args;
                 process.StartInfo.WindowStyle = ProcessWindowStyle.Normal;
                 process.StartInfo.CreateNoWindow = false;

--- a/CinematicRendererMod_Framework/Mono/src/VideoRenderer.cs
+++ b/CinematicRendererMod_Framework/Mono/src/VideoRenderer.cs
@@ -109,7 +109,7 @@ namespace LemmyModFramework
                 Process process = new Process();
                 process.StartInfo.FileName = "CMD.exe";
                 string args = "/C .\\ffmpeg.exe " + "-pattern_type sequence -r 60 -i \"" + dir +
-                              "\\Video_%05d.tga\" -c:v libx264 -preset veryfast -pix_fmt yuv444p -r 60 -b:v "Screen.width * Screen.height * 24"M -s:v " + Screen.width + "x" +
+                              "\\Video_%05d.tga\" -c:v libx264 -preset veryfast -pix_fmt yuv444p -r 60 -b:v "Screen.width * Screen.height * 25"M -s:v " + Screen.width + "x" +
                               Screen.height + " \"" + dir + "\\CINEMATIC_" + DateTime.Now.ToString("yyyy-MM-dd_hh-mm-ss") + ".MP4\"" ;
                 process.StartInfo.Arguments = args;
                 process.StartInfo.WindowStyle = ProcessWindowStyle.Normal;


### PR DESCRIPTION
Changed to read input always at 60 fps, not to read at regional framerate causing framte duplication and jittery motion. Made file naming scheme date-based. Made encoding faster. Made encoding use adequate bit rates dependatnt on screen res for high quality cinematics.